### PR TITLE
Fix #4: Ignore deleted comments when looking up existing comments

### DIFF
--- a/lib/actions/comments.js
+++ b/lib/actions/comments.js
@@ -5,7 +5,12 @@ const Q = require('q');
 const {BitbucketClient} = require('../bitbucket');
 const {loadAndroidLintResults, loadCheckstyleResults} = require('../loaders');
 
-module.exports = {executeCommentsAction};
+module.exports = {
+	executeCommentsAction,
+	_test: {
+		getPreviousCommentIds, /* testing only, should probably do better than this but for now will do */
+	},
+};
 
 function executeCommentsAction({args, config, credentials}) {
 	
@@ -111,6 +116,10 @@ function getPreviousCommentIds({ currentUser, existingComments, messageIdentifie
 	return existingComments.filter(isPreviousComment).map(comment => comment.id);
 
 	function isPreviousComment(comment) {
+		// we don't care for deleted or unknown author comments
+		if (comment.deleted || !comment.user) {
+			return false;
+		}
 		return comment.user.username === currentUser.username && comment.content.raw.endsWith(messageIdentifier);
 	}
 }

--- a/lib/actions/comments.spec.js
+++ b/lib/actions/comments.spec.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const chai = require('chai');
+const {_test} = require('./comments');
+
+const {getPreviousCommentIds} = _test;
+
+describe('Action Comments', () => {
+	describe('when calling getPreviousCommentIds', () => {
+		
+		const currentUser = { username: 'bob' };
+		const messageIdentifier = '.:id:.';
+		
+		it('ignores deleted comments', () => {
+			const expected = [1];
+			const got = getPreviousCommentIds({ 
+				currentUser,
+				existingComments: [{
+					id: 1,
+					deleted: false,
+					user: { username: currentUser.username },
+					content: { raw: `My message ${messageIdentifier}` },
+				}, {
+					id: 2,
+					deleted: true,
+					user: { username: currentUser.username },
+					content: { raw: `My message ${messageIdentifier}` },
+				}],
+				messageIdentifier,
+			});
+			chai.expect(got).deep.equal(expected);
+		});
+		it('ignores comments without a "user"', () => {
+			const expected = [1];
+			const got = getPreviousCommentIds({ 
+				currentUser,
+				existingComments: [{
+					id: 1,
+					deleted: false,
+					user: { username: currentUser.username },
+					content: { raw: `My message ${messageIdentifier}` },
+				}, {
+					id: 2,
+					deleted: false,
+					user: null,
+					content: { raw: `My message ${messageIdentifier}` },
+				}],
+				messageIdentifier,
+			});
+			chai.expect(got).deep.equal(expected);
+		});
+		it('only returns comments that match the user and identifier', () => {
+			const expected = [1];
+			const got = getPreviousCommentIds({ 
+				currentUser,
+				existingComments: [{
+					id: 1,
+					deleted: false,
+					user: { username: currentUser.username },
+					content: { raw: `My message ${messageIdentifier}` },
+				}, {
+					id: 2,
+					deleted: false,
+					user: { username: currentUser.username },
+					content: { raw: `My message .:otherId:.` },
+				}, {
+					id: 2,
+					deleted: false,
+					user: { username: `Other ${currentUser.username}` },
+					content: { raw: `My message ${messageIdentifier}` },
+				}],
+				messageIdentifier,
+			});
+			chai.expect(got).deep.equal(expected);
+		});
+	});
+});


### PR DESCRIPTION
Before we make new comments we clean up existing comments by the same user containing the same message identifier.