### PR TITLE
Fix node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
   - "6"
-  - "node"
+  - "8"
 after_success:
   - "yarn run coveralls"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"precommit": "lint-staged"
 	},
 	"engines": {
-		"node": ">=6.0.0"
+		"node": ">=6.0.0 <9.0.0"
 	},
 	"nyc": {
 		"exclude": ["**/*.spec.js"]


### PR DESCRIPTION
mock-fs does not play well with node version 11. Setting the max node to
8.x to make the test more reliable, and as such the app more reliable.