### PR TITLE
Added default for filename

### DIFF
--- a/lib/git/changed-chunks.js
+++ b/lib/git/changed-chunks.js
@@ -44,7 +44,7 @@ class ChangedChunks {
 	}
 }
 
-function compareFileNames(fileNameA, fileNameB) {
+function compareFileNames(fileNameA = '', fileNameB = '') {
 	const filePartsA = fileNameA.split('/').reverse();
 	const filePartsB = fileNameB.split('/').reverse();
 


### PR DESCRIPTION
parse-diff occassionally parses wrong filenames, for example on --
--------------, we get undefined from the file.to. This prevents that
from breaking the app.